### PR TITLE
refactor: simplify wildcard routes (#124)

### DIFF
--- a/middleware/stemmaweb_middleware/app.py
+++ b/middleware/stemmaweb_middleware/app.py
@@ -61,10 +61,8 @@ def register_blueprints(app: Flask):
 
     :param app: The Flask application object.
     """
-    # Stemmarest API endpoints, hybrid permissions
-    api_endpoints = app.config["STEMMAWEB_API_ENDPOINTS"]
     client = app.config["STEMMAREST_CLIENT"]
-    api_blueprint = controller.api.routes.blueprint_factory(api_endpoints, client)
+    api_blueprint = controller.api.routes.blueprint_factory(client)
     app.register_blueprint(api_blueprint)
 
     # Middleware-API endpoints to handle auth

--- a/middleware/stemmaweb_middleware/controller/api/routes.py
+++ b/middleware/stemmaweb_middleware/controller/api/routes.py
@@ -1,7 +1,6 @@
 from flask import Blueprint, Request, request
 from flask.wrappers import Response
 from loguru import logger
-from werkzeug.routing import Rule
 
 from stemmaweb_middleware.permissions import current_user, determine_user_role
 from stemmaweb_middleware.permissions.models import PermissionArguments
@@ -9,17 +8,13 @@ from stemmaweb_middleware.stemmarest import StemmarestClient
 from stemmaweb_middleware.stemmarest.permissions import (
     get_stemmarest_permission_handler,
 )
-from stemmaweb_middleware.stemmarest.stemmarest_endpoints import StemmarestEndpoints
 from stemmaweb_middleware.utils import abort, files_to_bytes
 
 
-def blueprint_factory(
-    endpoints: StemmarestEndpoints, stemmarest_client: StemmarestClient
-):
+def blueprint_factory(stemmarest_client: StemmarestClient):
     """
     Creates a Flask blueprint to expose the Stemmarest API at `/api/*`.
 
-    :param endpoints: `StemmarestEndpoints` object containing endpoint information.
     :param stemmarest_client: `StemmarestClient` to interact with the Stemmarest API.
     :return: the configured Flask blueprint.
     """
@@ -28,82 +23,80 @@ def blueprint_factory(
     ROUTE_PREFIX = "/api"
     permission_handler = get_stemmarest_permission_handler(stemmarest_client)
 
-    def wildcard_route_handler_func_factory(rule: Rule, nesting_level: int):
+    @blueprint.route(f"/{ROUTE_PREFIX}", methods=["GET"])
+    @blueprint.route(f"/{ROUTE_PREFIX}/", methods=["GET"])
+    def passthrough_health():
         """
-        Creates a function to handle wildcard routes
-        associated with the supplied `rule` at the given `nesting_level`.
+        Handler catching incoming GET requests to `/api` and `/api/`.
+        Returns a 200 status code and a message
+        indicating that the passthrough is healthy.
 
-        :param rule: the `Rule` object associated with the wildcard route.
-        :param nesting_level: the nesting level of the wildcard route.
-        :return: the function to handle the wildcard route,
-                 to be registered via `add_url_rule`.
+        :return: a tuple containing a message and a 200 status code.
         """
+        return "Passthrough is healthy", 200
 
-        def handler(**kwargs):
-            path_segments = tuple(kwargs.values())
-            args = PermissionArguments(
-                method=request.method,
-                endpoint=request.path,
-                path_segments=path_segments,
-                query_params=request.args.to_dict(),
-                data=__extract_data_from_request(request),
-                headers=dict(request.headers),
-                user=current_user,
-                user_role=determine_user_role(current_user),
-            )
+    @blueprint.route(f"/{ROUTE_PREFIX}/<path:segments>", methods=ALLOWED_METHODS)
+    def wildcard(segments: str):
+        """
+        Handler catching incoming requests to `/api/*`.
+        After permission checks, the request is forwarded to the Stemmarest API.
 
-            stemmarest_endpoint = "/" + "/".join(path_segments)
-            logger.debug(
-                f'Passthrough requested for "{stemmarest_endpoint}" with args {args}'
-            )
-            (
-                violations,
-                allowed_http_methods,
-                response_transformer,
-            ) = permission_handler.check(args=args)
-
-            if request.method not in allowed_http_methods or len(violations) > 0:
-                return abort(
-                    status=403,
-                    message="The caller has insufficient permissions "
-                    "to access this resource.",
-                    body=dict(violations=violations),
-                )
-
-            try:
-                response = stemmarest_client.request(
-                    path=stemmarest_endpoint,
-                    method=args["method"],
-                    params=args["query_params"],
-                    data=args["data"],
-                    files=files_to_bytes(request.files),
-                )
-                if response_transformer is not None:
-                    logger.debug("Applying response transformer")
-                    response = response_transformer(response)
-
-                return Response(
-                    response=response.content,
-                    status=response.status_code,
-                    mimetype=response.headers.get("Content-Type", None),
-                )
-            except Exception as e:
-                return abort(
-                    status=500,
-                    message="An error occurred while processing the request.",
-                    body=dict(type=f"{type(e).__name__}", message=str(e)),
-                )
-
-        return handler
-
-    # Actually register the wildcard routes with the handlers
-    for i, r in enumerate(endpoints.rules):
-        blueprint.add_url_rule(
-            rule="/".join([ROUTE_PREFIX, r.rule]).replace("//", "/"),
-            endpoint=r.endpoint,
-            view_func=wildcard_route_handler_func_factory(rule=r, nesting_level=i),
-            methods=ALLOWED_METHODS,
+        :param segments:
+        :return:
+        """
+        path_segments = tuple(segment for segment in segments.split("/") if segment)
+        args = PermissionArguments(
+            method=request.method,
+            endpoint=request.path,
+            path_segments=path_segments,
+            query_params=request.args.to_dict(),
+            data=__extract_data_from_request(request),
+            headers=dict(request.headers),
+            user=current_user,
+            user_role=determine_user_role(current_user),
         )
+
+        stemmarest_endpoint = "/" + "/".join(path_segments)
+        logger.debug(
+            f'Passthrough requested for "{stemmarest_endpoint}" with args {args}'
+        )
+        (
+            violations,
+            allowed_http_methods,
+            response_transformer,
+        ) = permission_handler.check(args=args)
+
+        if request.method not in allowed_http_methods or len(violations) > 0:
+            return abort(
+                status=403,
+                message="The caller has insufficient permissions "
+                "to access this resource.",
+                body=dict(violations=violations),
+            )
+
+        try:
+            response = stemmarest_client.request(
+                path=stemmarest_endpoint,
+                method=args["method"],
+                params=args["query_params"],
+                data=args["data"],
+                files=files_to_bytes(request.files),
+            )
+            if response_transformer is not None:
+                logger.debug("Applying response transformer")
+                response = response_transformer(response)
+
+            return Response(
+                response=response.content,
+                status=response.status_code,
+                mimetype=response.headers.get("Content-Type", None),
+            )
+        except Exception as e:
+            return abort(
+                status=500,
+                message="An error occurred while processing the request.",
+                body=dict(type=f"{type(e).__name__}", message=str(e)),
+            )
 
     return blueprint
 

--- a/middleware/stemmaweb_middleware/settings.py
+++ b/middleware/stemmaweb_middleware/settings.py
@@ -5,7 +5,6 @@ from environs import Env
 from loguru import logger
 
 from stemmaweb_middleware.stemmarest.stemmarest_client import StemmarestClient
-from stemmaweb_middleware.stemmarest.stemmarest_endpoints import StemmarestEndpoints
 from stemmaweb_middleware.utils import RecaptchaVerifier
 
 from . import constants
@@ -27,7 +26,6 @@ STEMMAREST_CLIENT = StemmarestClient(endpoint=STEMMAREST_ENDPOINT)
 STEMMAWEB_MIDDLEWARE_URL = env.str(
     "STEMMAWEB_MIDDLEWARE_URL", default="http://127.0.0.1:3000"
 )
-STEMMAWEB_API_ENDPOINTS = StemmarestEndpoints(middleware_url=STEMMAWEB_MIDDLEWARE_URL)
 
 # Used for Flask-Login
 # Session Docs: https://flask.palletsprojects.com/en/2.1.x/quickstart/#sessions

--- a/middleware/stemmaweb_middleware/stemmarest/stemmarest_endpoints.py
+++ b/middleware/stemmaweb_middleware/stemmarest/stemmarest_endpoints.py
@@ -1,8 +1,5 @@
-import re
 from enum import Enum
 from typing import Optional
-
-from werkzeug.routing import Map, Rule
 
 
 class StemmarestEndpoint(Enum):
@@ -33,30 +30,3 @@ class StemmarestEndpoint(Enum):
             if path.startswith(f"/{first_segment}"):
                 return endpoint
         return None
-
-
-def nested_url_rule(level: int, endpoint="global_wildcard") -> Rule:
-    endpoint_name = f"{endpoint}_{level}"
-    segments = [f"<s{i}>" for i in range(1, level + 1)]
-    return Rule("/" + "/".join(segments), endpoint=endpoint_name)
-
-
-class StemmarestEndpoints:
-    def __init__(self, middleware_url: str):
-        # extract `server_name` and `path_info` from `middleware_url`
-        # e.g. "http://localhost:8080/stemmaweb/requests" ->
-        # server_name = "http://localhost:8080", path_info = "/stemmaweb/requests"
-        pattern = r"(?P<server_name>https?://[^/]+)(?P<path_info>.*)"
-        match = re.match(pattern, middleware_url)
-        if match is None:
-            raise ValueError(
-                f"Invalid `middleware_url`={middleware_url}. "
-                f"Expected format: http[s]://<host>[:<port>][/<path>]"
-            )
-        server_name = match.group("server_name")
-        path_info = match.group("path_info") or "/"
-
-        # URL Rules to catch requests up to a nesting level of 10
-        # E.g.: /seg1/seg2/seg3/seg4/seg5/seg6/seg7/seg8/seg9/seg10
-        self.rules = [nested_url_rule(i) for i in range(1, 10 + 1)]
-        self.urls = Map(self.rules).bind(server_name=server_name, path_info=path_info)


### PR DESCRIPTION
### Goals

- Replace the hard-coded dynamic nested URL rule generation - based approach to catch requests arriving to `/api/*` and forward it to Stemmarest.

### Notes

- source:  https://www.reddit.com/r/flask/comments/6ppkd6/dynamic_or_wildcard_routing/ via @tla
- The same approach will be implemented for #103 to forward requests to Stemweb

Reworks ea9dce23942baafe6d309633aef75b3df959b257 introduced in #105.

Closes #124