### PR TITLE
docs: end-to-end docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,20 @@ the [Stemmarest](http://dhuniwien.github.io/tradition_repo/) data model.
 - [Overview](#overview)
 - [Trying it out](#trying-it-out--eventually-)
 - [Development](#development)
+    - [Decrypting Environment Variables](#decrypting-environment-variables)
+    - [Encrypting Environment Variables](#encrypting-environment-variables)
     - [Docker](#docker)
     - [Local](#local)
+- [Testing](#testing)
 
 ## Overview
 
-The system is made up of three main components:
+The system is made up of four main components:
 
 - The [Stemmarest](http://dhuniwien.github.io/tradition_repo/) backend, which
   provides a RESTful API for accessing and manipulating text traditions.
+- The [Stemweb](https://github.com/DHUniWien/Stemweb) backend, which
+  provides a RESTful API for running stemmatological algorithms.
 - The [Stemmaweb Middleware](./middleware/README.md) which provides an authentication and authorization
   layer on top of the Stemmarest API. The frontend communicates only with this layer directly.
 - The [Stemmaweb Frontend](./frontend/README.md) which provides a web interface for
@@ -26,7 +31,7 @@ The system is made up of three main components:
 
 A prerequisite for using Stemmaweb is to have [Make](https://www.gnu.org/software/make/),
 [Docker](https://www.docker.com/) and [docker-compose](https://docs.docker.com/compose/) installed on your machine. You
-also need to configure the environment variables, to do so you can use `.env.prod.example` as a template. After filling
+also need to configure the environment variables. To do so you can use `.env.prod.example` as a template. After filling
 in the missing values (or leaving them as they are), rename the file to `.env.prod`.
 
 Once you have these, you can run the following command to get a working instance of Stemmaweb:

--- a/middleware/DEVELOPMENT.md
+++ b/middleware/DEVELOPMENT.md
@@ -4,6 +4,9 @@ The main purpose of the middleware is to forward requests to the Stemmarest back
 
 - Authentication using email-password or Google OAuth
 - Authorization based on the user's role (*Guest*, *User*, *Admin*)
+- Expose all the external
+  services ([Stemmarest](http://dhuniwien.github.io/tradition_repo/), [Stemweb](https://github.com/DHUniWien/Stemweb))
+  to the frontend through a uniform API
 
 The frontend communicates with the middleware using REST endpoints. The middleware is built
 using [Flask](http://flask.pocoo.org/), a Python microframework.
@@ -45,28 +48,71 @@ The middleware is highly modular. Its most notable parts are described below.
 - `stemmaweb_middleware/controller/*`: Contains the logic for the REST endpoints.
 - `stemmaweb_middleware/permissions/*`: Contains the logic based on which user permissions are granted. Provides a
   declarative mini-framework for associating user roles with server resources.
-- `stemmaweb_middleware/stemmarest/*`: Wrapper around the Stemmarest backend. Provides a client class with which
-  requests can be made to the backend in a type-safe manner with automatic logging and error handling.
+- `stemmaweb_middleware/resources/`: Module encapsulating interaction logic with external services, such as Stemmarest
+  and Stemweb.
+    - `stemmaweb_middleware/resources/base/*`: Wrapper around the Stemmarest backend.
+    - `stemmaweb_middleware/resources/stemmarest/*`: Wrapper around the Stemmarest backend.
+    - `stemmaweb_middleware/resources/stemweb/*`: Provides a client class with which requests can be made to the backend
+      in a type-safe manner with automatic logging and error handling and passthrough logic to be shared across
+      resources.
+- `stemmaweb_middleware/utils/*`: Various utility functions used throughout the project.
 - `stemmaweb_middleware/app.py`: The main entry point of the middleware. Contains the Flask app and the
-  initialization logic.
+  initialization logic, such as logger configuration, extension registration, dependency injection, etc.
 - `stemmaweb_middleware/constants.py`: Used to declare various constants used throughout the project.
 - `stemmaweb_middleware/extensions.py`: Collects all Flask extensions used in the project.
 - `stemmaweb_middleware/models.py`: Contains the shared models used by the middleware.
 - `stemmaweb_middleware/settings.py`: Contains the settings for the Flask app. Reads the settings from the
   environment variables.
-- `stemmaweb_middleware/utils.py`: Contains various utility functions used throughout the project.
 
 ## Middleware Design
 
 ### Authentication
 
-Users can authenticate using either email-password or Google OAuth. The middleware
+Users can authenticate using either email-password or OAuth providers, such as GitHub and Google. The middleware
 uses [Flask-Login](https://flask-login.readthedocs.io/en/latest/) to manage user sessions. As soon as a user logs in
 using valid credentials, a session is created and returned to the client as a cookie. The client must send this session
 cookie with every request to the middleware.
 
 The actual endpoints and the implementation of the authentication logic can be found
 in the [`stemmaweb_middleware/controller/auth`](./stemmaweb_middleware/controller/auth) module.
+
+### Forwarding Requests to External Services
+
+In what follows, we will describe the logic for forwarding requests to external services using Stemmarest as a concrete
+example. The same logic applies for the Stemweb component too.
+
+After successful authentication and authorization, the middleware forwards the request to the Stemmarest backend.
+Instead of defining every single possible Stemmarest endpoint based
+on [its docs](https://dhuniwien.github.io/tradition_repo) we are forwarding each request arriving to the
+middleware's `/api` endpoint automatically with all the necessary headers and parameters. This means, that clients of
+the middleware should use the same endpoint signatures as the Stemmarest backend.
+
+It is important to note that only those endpoints are forwarded to the specific external service that are explicitly
+defined in the `<service>_endpoints.py` module. The concrete modules are:
+
+- [stemmaweb_middleware/resources/stemmarest/stemmarest_endpoints.py](stemmaweb_middleware/resources/stemmarest/stemmarest_endpoints.py)
+- [stemmaweb_middleware/resources/stemweb/stemweb_endpoints.py](stemmaweb_middleware/resources/stemweb/stemweb_endpoints.py)
+
+#### All available endpoints
+
+- [Stemmarest](https://dhuniwien.github.io/tradition_repo/)
+- [Stemweb](https://github.com/tla/stemmaweb/issues/103#issuecomment-1416056239)
+
+#### Concrete Example
+
+For example, we have the following declarations for Stemmarest:
+
+```python
+# Extract from stemmaweb_middleware/resources/stemmarest/stemmarest_endpoints.py
+class StemmarestEndpoint(Enum):
+    """Enum class to represent Stemmarest API endpoints."""
+
+    TRADITIONS = "/traditions"
+    TRADITION = "/tradition/{tradId}"
+    USERS = "/users"
+    USER = "/user/{userId}"
+    READING = "/reading/{readingId}"
+```
 
 ### Authorization
 
@@ -76,22 +122,11 @@ the [`stemmaweb_middleware/permissions`](./stemmaweb_middleware/permissions) mod
 in [`stemmaweb_middleware/resources/stemmarest/permissions/declarations`](stemmaweb_middleware/resources/stemmarest/permissions/declarations)
 .
 
-### Forwarding Requests to the Stemmarest Backend
+#### A Hands-on Example
 
-After successful authentication and authorization, the middleware forwards the request to the Stemmarest backend.
-Instead of defining every single possible Stemmarest endpoint based
-on [its docs](https://dhuniwien.github.io/tradition_repo) we are forwarding each request arriving to the
-middleware's `/api` endpoint automatically with all the necessary headers and parameters. This means, that clients of
-the middleware should use the same endpoint signatures as the Stemmarest backend.
+To illustrate how custom authorization logic can be implemented, we use a concrete example, in which we define a rule
+over the Stemmarest component. The rule states that only logged-in users can delete a tradition, that is, a user with
+role *User* or *Admin*.
 
-#### Catching Wildcard Endpoints
-
-Due to the fact that Flask does not support wildcard endpoints, we are defining routes dynamically up to 10 levels deep.
-In practice this looks like as depicted below:
-
-- `/api/<lvl0>` to catch requests without nesting, e.g `/users`, `/traditions`, etc.
-- `/api/<lvl0>/<lvl1>` to catch requests where we have a single level of nesting, eg `/reading/<readingId>`, ...
-- `/api/<lvl0>/<lvl1>/...` and so on...
-
-This logic is implemented
-in [`stemmaweb_middleware/controller/api/routes.py`](./stemmaweb_middleware/controller/api/routes.py).
+We know from the [Stemmarest docs](https://dhuniwien.github.io/tradition_repo/) that we need to send a `DELETE` request
+to `/tradition/{tradId}/` in order to delete a tradition. 

--- a/middleware/README.md
+++ b/middleware/README.md
@@ -4,6 +4,12 @@ This module holds the source code of the middleware that is used to connect the 
 of authentication and authorization. The middleware is a Python Flask application, exposing REST endpoints to the
 frontend.
 
+**Table of Contents**
+
+- [Running Locally](#running-locally)
+    - [Running with Poetry](#running-with-poetry)
+    - [Running with Docker](#running-with-docker)
+
 ## Running Locally
 
 You can decide whether you would like to run the application locally using [Docker](https://www.docker.com/) or by
@@ -14,7 +20,7 @@ successfully. As the table below shows, some of these have default values (hence
 required.
 
 | Variable                   | Description                                                                                                                                                                                                      | Default                            |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+|----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
 | `STEMMAREST_ENDPOINT`      | The URL where the Stemmarest backend is running                                                                                                                                                                  | `http://127.0.0.1:8080/stemmarest` |
 | `STEMMAWEB_MIDDLEWARE_URL` | The URL where this middleware is running                                                                                                                                                                         | `http://127.0.0.1:3000`            |
 | `SECRET_KEY`               | Secret key for the Flask application, used by [Flask-Login](https://github.com/maxcountryman/flask-login).<br />Generate it by executing `python -c 'import secrets; print(secrets.token_hex())'` in your shell. | 🚫                                 |
@@ -47,7 +53,7 @@ poetry install
 make serve
 ```
 
-### Running with Docker
+## Running with Docker
 
 Build the image using the following command:
 
@@ -71,3 +77,8 @@ docker run -it \
 	-e LOG_BACKTRACE=True \
 	stemmaweb-middleware
 ```
+
+Please note that in most cases running the middleware alone is not desired, since it is a single component of a
+broader stack. It is highly advised to run the whole stack using the [Docker Compose](https://docs.docker.com/compose/),
+as described in the project's root-level [README](../README.md). In that case, all the environment variables will be
+sourced from the root-level `.env*` files.

--- a/middleware/stemmaweb_middleware/permissions/base_handler.py
+++ b/middleware/stemmaweb_middleware/permissions/base_handler.py
@@ -15,6 +15,11 @@ from .models import (
 
 
 class BasePermissionHandler(ABC, Generic[EndpointType]):
+    """
+    This class implements the permission checking logic in a generic way,
+    using the supplied ``PermissionProvider`` to retrieve the configuration.
+    """
+
     def __init__(self, provider: PermissionProvider[EndpointType], name: str):
         self.provider = provider
         self.name = name

--- a/middleware/stemmaweb_middleware/permissions/models.py
+++ b/middleware/stemmaweb_middleware/permissions/models.py
@@ -134,16 +134,12 @@ class EndpointAccess(pydantic.BaseModel):
     If no (valid) session cookie is present, the user is a guest. If a session
     cookie is present, we extract the user ID from it and check the database for
     the user's actual role.
-
-    If `inverted` is set to True, the predicate is inverted, that is, if the predicate
-    evaluates to True, the permissions are **not** granted.
     """
 
     name: str
     description: str | None = None
     predicate: EndpointAccessPredicate
     if_true: set[Permission]
-    inverted: bool = False
 
     def to_violation_str(self):
         """

--- a/middleware/stemmaweb_middleware/permissions/models.py
+++ b/middleware/stemmaweb_middleware/permissions/models.py
@@ -115,12 +115,41 @@ EndpointAccessPredicate = Callable[[PermissionArguments], bool]
 
 
 class EndpointAccess(pydantic.BaseModel):
+    """
+    Model describing the access to an endpoint.
+    It defines a ``name`` and ``description`` for debugging purposes,
+    as well as a ``predicate`` callback function that gets evaluated
+    whenever an endpoint associated with an instance of this class is accessed.
+    In case of a positive evaluation, the ``if_true`` permissions are granted.
+    The permissions represent the HTTP methods that are allowed for the endpoint.
+
+    This is necessary, since there are endpoints such as Stemmarest's
+    ``/tradition/{tradId}/``, where only GET is allowed for guests,
+    while PUT, and DELETE are allowed for users and admins.
+
+    Using an ``EndpointAccess`` instance, we can enforce this logic
+    by creating a ``predicate`` that checks the ``PermissionArguments``
+    for a user's role. Under the hood, we check the session cookie,
+    based on which the user role can be determined.
+    If no (valid) session cookie is present, the user is a guest. If a session
+    cookie is present, we extract the user ID from it and check the database for
+    the user's actual role.
+
+    If `inverted` is set to True, the predicate is inverted, that is, if the predicate
+    evaluates to True, the permissions are **not** granted.
+    """
+
     name: str
     description: str | None = None
     predicate: EndpointAccessPredicate
     if_true: set[Permission]
+    inverted: bool = False
 
     def to_violation_str(self):
+        """
+        :return: a string representation of the violation.
+                 Gets returned to the frontend in case of permission violations.
+        """
         res = self.name
         if self.description is not None:
             res += f": {self.description}"
@@ -159,6 +188,21 @@ class PermissionCheckResult(NamedTuple):
 
 
 class Matchable(Protocol):
+    """
+    Protocol for classes that implement a `match` method, used
+    to match against a path.
+
+    The actual classes complying with this protocol currently are
+    stemmarest_endpoints.py::StemmarestEndpoint and
+    stemweb_endpoints.py::StemwebEndpoint.
+
+    The matching mechanism is used for the passthrough logic,
+    so that whenever a Flask wildcard route is invoked, we can
+    associate the requested endpoint with a static, managed endpoint.
+    This is necessary so that we can associate permissions with given endpoints
+    in an explicit, declarative way.
+    """
+
     @staticmethod
     def match(path: str) -> Optional["Matchable"]:
         pass
@@ -168,14 +212,29 @@ EndpointType = TypeVar("EndpointType", bound=Matchable)
 
 
 class PermissionProvider(ABC, Generic[EndpointType]):
+    """
+    Interface for classes to provide permission configuration for a given resource.
+    We use permission providers for Stemweb and Stemmarest endpoints.
+    """
+
     @abstractmethod
     def get_permission_config(
         self,
         permission_arguments: PermissionArguments,
     ) -> dict[EndpointType, dict[UserRole, list[PermissionConfig]]]:
+        """
+        Returns a dictionary of permissions per user role for a given endpoint
+        based on the supplied ``permission_arguments``.
+
+        :param permission_arguments: the arguments arriving with the request
+        :return: a dictionary of permissions per user role for a given endpoint
+        """
         raise NotImplementedError
 
     @property
     @abstractmethod
     def endpoint_type(self) -> type[EndpointType]:
+        """
+        :return: the type of the endpoint this provider is responsible for
+        """
         raise NotImplementedError

--- a/middleware/stemmaweb_middleware/permissions/predicates.py
+++ b/middleware/stemmaweb_middleware/permissions/predicates.py
@@ -1,3 +1,7 @@
+"""
+This module collects utility methods to make it easier to define
+endpoint access predicates.
+"""
 from stemmaweb_middleware.permissions.models import (
     EndpointAccessPredicate,
     PermissionArguments,
@@ -5,14 +9,35 @@ from stemmaweb_middleware.permissions.models import (
 
 
 def always_true(args: PermissionArguments) -> bool:
+    """
+    Always returns True.
+
+    :param args: The permission arguments.
+    :return: True.
+    """
     return True
 
 
 def always_false(args: PermissionArguments) -> bool:
+    """
+    Always returns False.
+
+    :param args: The permission arguments.
+    :return: False.
+    """
     return False
 
 
 def has_query_params(key: str, value: str) -> EndpointAccessPredicate:
+    """
+    Returns a predicate that checks if the query parameters contain a
+    key-value pair.
+
+    :param key: the key to check
+    :param value: the value to check
+    :return: the predicate
+    """
+
     def pred(args: PermissionArguments) -> bool:
         return args["query_params"].get(key, "").lower() == value
 

--- a/middleware/stemmaweb_middleware/resources/base/passthrough_handler.py
+++ b/middleware/stemmaweb_middleware/resources/base/passthrough_handler.py
@@ -39,7 +39,9 @@ def handle_passthrough_request(
             status=403,
             message="The caller has insufficient permissions "
             "to access this resource.",
-            body=dict(violations=violations),
+            body=dict(
+                violations=violations, allowed_http_methods=list(allowed_http_methods)
+            ),
         )
 
     try:

--- a/middleware/stemmaweb_middleware/resources/base/passthrough_handler.py
+++ b/middleware/stemmaweb_middleware/resources/base/passthrough_handler.py
@@ -28,12 +28,15 @@ def handle_passthrough_request(
 
     api_endpoint = "/" + "/".join(path_segments) + "/"
     logger.debug(f'Passthrough requested for "{api_endpoint}" with args {args}')
+
+    # The heavy-lifting for permission checking is done in `permission_handler.check`
     (
         violations,
         allowed_http_methods,
         response_transformer,
     ) = permission_handler.check(args=args)
 
+    # If the user is not allowed to access the requested endpoint, we abort the request
     if request.method not in allowed_http_methods or len(violations) > 0:
         return abort(
             status=403,
@@ -44,6 +47,7 @@ def handle_passthrough_request(
             ),
         )
 
+    # Otherwise, we allow the request to pass through
     try:
         response = client.request(
             path=api_endpoint,

--- a/middleware/stemmaweb_middleware/resources/stemmarest/permissions/declarations/tradition.py
+++ b/middleware/stemmaweb_middleware/resources/stemmarest/permissions/declarations/tradition.py
@@ -29,7 +29,7 @@ def config(
             ),
         )
     ]
-    tradition_config_guest = []
+    tradition_config_guest: list[PermissionConfig] = []
     tradition_config_user = [*base_config]
     tradition_config_admin = [*base_config]
     tradition_config = {

--- a/middleware/stemmaweb_middleware/resources/stemmarest/permissions/declarations/tradition.py
+++ b/middleware/stemmaweb_middleware/resources/stemmarest/permissions/declarations/tradition.py
@@ -19,19 +19,25 @@ def config(
     service: StemmarestPermissionService, args: PermissionArguments
 ) -> dict[UserRole, list[PermissionConfig]]:
     """Role-based configuration for the `/tradition/*` Stemmarest endpoint."""
-    base_config = [
-        PermissionConfig(
-            endpoint_access=EndpointAccess(
-                name="Allow all",
-                description="Allowing full access for now",
-                predicate=perm_predicates_base.always_true,
-                if_true={Permission.READ, Permission.WRITE},
-            ),
-        )
-    ]
-    tradition_config_guest: list[PermissionConfig] = []
-    tradition_config_user = [*base_config]
-    tradition_config_admin = [*base_config]
+    read_write = PermissionConfig(
+        endpoint_access=EndpointAccess(
+            name="Allow read-write",
+            description="Allowing read-write access",
+            predicate=perm_predicates_base.always_true,
+            if_true={Permission.READ, Permission.WRITE},
+        ),
+    )
+    read_only = PermissionConfig(
+        endpoint_access=EndpointAccess(
+            name="Allow read-only",
+            description="Allowing read-only access",
+            predicate=perm_predicates_base.always_true,
+            if_true={Permission.READ},
+        ),
+    )
+    tradition_config_guest = [read_only]
+    tradition_config_user = [read_write]
+    tradition_config_admin = [read_write]
     tradition_config = {
         UserRole.GUEST: tradition_config_guest,
         UserRole.USER: tradition_config_user,

--- a/middleware/stemmaweb_middleware/resources/stemmarest/permissions/declarations/tradition.py
+++ b/middleware/stemmaweb_middleware/resources/stemmarest/permissions/declarations/tradition.py
@@ -29,7 +29,7 @@ def config(
             ),
         )
     ]
-    tradition_config_guest = [*base_config]
+    tradition_config_guest = []
     tradition_config_user = [*base_config]
     tradition_config_admin = [*base_config]
     tradition_config = {

--- a/middleware/stemmaweb_middleware/resources/stemmarest/permissions/filter.py
+++ b/middleware/stemmaweb_middleware/resources/stemmarest/permissions/filter.py
@@ -4,6 +4,13 @@ from stemmaweb_middleware.permissions.models import PermissionArguments
 
 
 def public_resources_only(response: Any) -> list[dict]:
+    """
+    Response transformer that filters out all resources that are not public.
+    We determine whether a resource is public by checking the `is_public` field.
+
+    :param response: The response to transform.
+    :return: A list of dictionaries, each of which represents a public resource.
+    """
     if not isinstance(response, list):
         return response
     list_of_dicts: list[dict] = response
@@ -11,6 +18,13 @@ def public_resources_only(response: Any) -> list[dict]:
 
 
 def owned_resources_only_factory(args: PermissionArguments):
+    """
+    Returns a response transformer that filters out all resources that are not
+    public or owned by the user making the request.
+
+    :param args: The permission arguments for the request.
+    :return: A response transformer.
+    """
     owner_id = ""
     try:
         owner_id = args["user"].id  # type: ignore
@@ -20,6 +34,15 @@ def owned_resources_only_factory(args: PermissionArguments):
 
 
 def _owned_resources_only(response: Any, owner_id: str) -> list[dict]:
+    """
+    Response transformer that filters out all resources that are not public or
+    owned by the user identified by ``owner_id``.
+
+    :param response: The response to transform.
+    :param owner_id: The ID of the user making the request.
+    :return: A list of dictionaries, each of which represents
+             a resource accessible to the user.
+    """
     if not isinstance(response, list):
         return response
     list_of_dicts: list[dict] = response

--- a/middleware/stemmaweb_middleware/resources/stemmarest/permissions/handler.py
+++ b/middleware/stemmaweb_middleware/resources/stemmarest/permissions/handler.py
@@ -15,6 +15,19 @@ class StemmarestPermissionHandler(BasePermissionHandler[StemmarestEndpoint]):
 def get_stemmarest_permission_handler(
     client: APIClient,
 ) -> StemmarestPermissionHandler:
+    """
+    Creates a new Stemmarest permission handler
+    via chained dependency injection.
+
+    The supplied ``client`` is used to create a ``StemmarestPermissionService``.
+    The ``StemmarestPermissionService`` is used
+    to create a ``StemmarestPermissionProvider``.
+    The ``StemmarestPermissionProvider`` is used
+    to create the ``StemmarestPermissionHandler``.
+
+    :param client: The ``APIClient`` to use.
+    :return: The new ``StemmarestPermissionHandler``.
+    """
     service = StemmarestPermissionService(client)
     provider = StemmarestPermissionProvider(service)
     handler = StemmarestPermissionHandler(provider)

--- a/middleware/stemmaweb_middleware/resources/stemweb/permissions/handler.py
+++ b/middleware/stemmaweb_middleware/resources/stemweb/permissions/handler.py
@@ -15,6 +15,19 @@ class StemwebPermissionHandler(BasePermissionHandler[StemwebEndpoint]):
 def get_stemweb_permission_handler(
     client: APIClient,
 ) -> StemwebPermissionHandler:
+    """
+        Creates a new Stemweb permission handler
+        via chained dependency injection.
+
+        The supplied ``client`` is used to create a ``StemwebPermissionService``.
+        The ``StemwebPermissionService`` is used
+        to create a ``StemwebPermissionProvider``.
+        The ``StemwebPermissionProvider`` is used
+        to create the ``StemwebPermissionHandler``.
+
+        :param client: The ``APIClient`` to use.
+        :return: The new ``StemwebPermissionHandler``.
+        """
     service = StemwebPermissionService(client)
     provider = StemwebPermissionProvider(service)
     handler = StemwebPermissionHandler(provider)

--- a/middleware/stemmaweb_middleware/resources/stemweb/permissions/handler.py
+++ b/middleware/stemmaweb_middleware/resources/stemweb/permissions/handler.py
@@ -16,18 +16,18 @@ def get_stemweb_permission_handler(
     client: APIClient,
 ) -> StemwebPermissionHandler:
     """
-        Creates a new Stemweb permission handler
-        via chained dependency injection.
+    Creates a new Stemweb permission handler
+    via chained dependency injection.
 
-        The supplied ``client`` is used to create a ``StemwebPermissionService``.
-        The ``StemwebPermissionService`` is used
-        to create a ``StemwebPermissionProvider``.
-        The ``StemwebPermissionProvider`` is used
-        to create the ``StemwebPermissionHandler``.
+    The supplied ``client`` is used to create a ``StemwebPermissionService``.
+    The ``StemwebPermissionService`` is used
+    to create a ``StemwebPermissionProvider``.
+    The ``StemwebPermissionProvider`` is used
+    to create the ``StemwebPermissionHandler``.
 
-        :param client: The ``APIClient`` to use.
-        :return: The new ``StemwebPermissionHandler``.
-        """
+    :param client: The ``APIClient`` to use.
+    :return: The new ``StemwebPermissionHandler``.
+    """
     service = StemwebPermissionService(client)
     provider = StemwebPermissionProvider(service)
     handler = StemwebPermissionHandler(provider)

--- a/middleware/stemmaweb_middleware/utils/api_response.py
+++ b/middleware/stemmaweb_middleware/utils/api_response.py
@@ -21,7 +21,7 @@ def abort(
     :return: A Flask Response.
     """
     log.error(f'Aborting with status "{status}", body "{body}" and message "{message}"')
-    processed_body: dict[str, Any] = {}
+    processed_body: dict[str, Any] = (isinstance(body, dict) and body) or {}
     body_is_pydantic_model = body is not None and not isinstance(body, dict)
     if body_is_pydantic_model:
         model: pydantic.BaseModel = body  # type: ignore


### PR DESCRIPTION
- Updated and extended the project documentation
- Added concrete example of the usage of the permission configurations
- Actually implemented a rule to prevent guests from deleting traditions, and more generally, perform any write operations on Stemmarest's `/tradition/*` route