### PR TITLE
Fix: fixes #256, #254, #245, and #250.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 .env*
 scratchpad
 HOURS.md
+next_commit_fixes_and_tests.md
 
 # Created by https://www.toptal.com/developers/gitignore/api/python
 # Edit at https://www.toptal.com/developers/gitignore?templates=python

--- a/frontend/www/src/css/dashboard-stemmaweb.css
+++ b/frontend/www/src/css/dashboard-stemmaweb.css
@@ -137,6 +137,7 @@ span.relation-colors.color-brown  svg.feather.feather-check-square {
 }
 
 .sidebar-menu .nav-link {
+  display: flex;
   font-weight: 500;
   color: #333;
   line-height: 1.15;
@@ -466,10 +467,12 @@ stemmaweb-alert {
 
 li.nav-item {
   padding: var(--bs-nav-link-padding-y) var(--bs-nav-link-padding-x);
+  cursor: pointer;
 }
 
 .folder-icon {
-  padding-right: 0.5em;
+  padding-right: 0.2em;
+  cursor: pointer;
 }
 
 .access-icon {
@@ -495,6 +498,10 @@ ul#traditions-list .folder-icon.selected svg {
 
 ul#traditions-list .list-separator {
   border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+section-list {
+  opacity: 0;
 }
 
 section-list ul {

--- a/frontend/www/src/css/dashboard-stemmaweb.css
+++ b/frontend/www/src/css/dashboard-stemmaweb.css
@@ -221,6 +221,7 @@ edit-stemma-buttons {
 
 edit-stemma-buttons a.greyed-out div, 
 edit-properties-button a.greyed-out span,
+.edit-reading-button a.greyed-out span,
 edit-section-properties-button a.greyed-out span,
 text-directory a.greyed-out span {
   color: #ccc;

--- a/frontend/www/src/js/modules/dashboard/textDirectory.js
+++ b/frontend/www/src/js/modules/dashboard/textDirectory.js
@@ -2,9 +2,9 @@ class TextDirectory extends HTMLElement {
 
     constructor() {
         super();
-        TRADITION_STORE.subscribe( ( state ) => {
+        AUTH_STORE.subscribe( ( state ) => {
             const textDirectoryElementClassList = document.querySelector( 'text-directory a' ).classList;
-            if( userIsOwner() ){
+            if( state.user ){
                 if( textDirectoryElementClassList.contains( 'greyed-out' ) ){
                     textDirectoryElementClassList.remove( 'greyed-out' );
                     this.addEventListener( 'click', this.clickEventListener );

--- a/frontend/www/src/js/modules/dashboard/tradition/editProperties.js
+++ b/frontend/www/src/js/modules/dashboard/tradition/editProperties.js
@@ -128,7 +128,12 @@ class EditProperties extends HTMLElement {
     const language = $('language_input').value || null;
     const direction = $('direction_input').value;
     const isPublic = $('access_input').checked;
-    const ownerId = $('owner_input').value;
+    let ownerId = null;
+    if ( userIsAdmin() ) {
+      ownerId = $('owner_input').value;
+    } else {
+      ownerId = AUTH_STORE.state.user ? AUTH_STORE.state.user.id : null;
+    }
     return { ownerId, name, language, direction, isPublic };
   }
 
@@ -140,7 +145,6 @@ class EditProperties extends HTMLElement {
         EditProperties.#extractFormValuesTradition()
       );
       const tradId = TRADITION_STORE.state.selectedTradition.id;
-      const userId = AUTH_STORE.state.user ? AUTH_STORE.state.user.id : null;
       return editPropertiesService
         .updateTraditionMetadata( tradId, ...values )
         .then( EditProperties.#handleUpdateTraditionMetadataResponse );

--- a/frontend/www/src/js/modules/dashboard/tradition/section/readingPropertiesView.js
+++ b/frontend/www/src/js/modules/dashboard/tradition/section/readingPropertiesView.js
@@ -108,14 +108,17 @@ class ReadingPropertiesView extends HTMLElement {
     }
 
     setReadingActionButtonsActive() {
-        // Do not activate buttons if no readings are selected. 
-        if( document.querySelector( '#reading-info tr' ) ) {
-            document.querySelector( 'split-nodes-button' ).setActive();
-            document.querySelector( 'detach-nodes-button' ).setActive();
-            // Do only show concatenate and merge buttons if multiple readings are selected.
-            if( document.querySelector( '#reading-info tr td.reading-property-column-header' ) ) {
-                document.querySelector( 'concatenate-nodes-button' ).setActive();
-                document.querySelector( 'merge-nodes-button' ).setActive();
+        // Is this user the owner?
+        if( userIsOwner() ) {
+            // Do not activate buttons if no readings are selected. 
+            if( document.querySelector( '#reading-info tr' ) ) {
+                document.querySelector( 'split-nodes-button' ).setActive();
+                document.querySelector( 'detach-nodes-button' ).setActive();
+                // Do only show concatenate and merge buttons if multiple readings are selected.
+                if( document.querySelector( '#reading-info tr td.reading-property-column-header' ) ) {
+                    document.querySelector( 'concatenate-nodes-button' ).setActive();
+                    document.querySelector( 'merge-nodes-button' ).setActive();
+                }
             }
         }
     }

--- a/frontend/www/src/js/modules/dashboard/tradition/section/sectionList.js
+++ b/frontend/www/src/js/modules/dashboard/tradition/section/sectionList.js
@@ -67,6 +67,10 @@ class SectionList extends HTMLElement {
         return sectionListItem ? sectionListItem.querySelector( 'div' ).getAttribute( 'sect-id' ) : 'none';
     }
 
+    getFirstSection() {
+        return this.#sections[0];
+    }
+    
     connectedCallback() {
         this.render();
         this.populate();
@@ -84,6 +88,9 @@ class SectionList extends HTMLElement {
                     // figure out tradition.id, section.id, priorSectionId.
                     const moveSectionId = this.getSectionId( evt, evt.newIndex );
                     const moveAfterSectionId = this.getSectionId( evt, evt.newIndex-1 );
+                    // Reflect new order in private list of sections.
+                    // See: https://stackoverflow.com/questions/5306680/move-an-array-element-from-one-array-position-to-another
+                    this.#sections.splice( evt.newIndex, 0, this.#sections.splice( evt.oldIndex, 1)[0] );
                     sectionService.moveSection( this.getAttribute( 'trad-id' ), moveSectionId, moveAfterSectionId )
                         .then( (resp) => {
                             if( !resp.success ) {
@@ -142,7 +149,6 @@ class SectionList extends HTMLElement {
                 (tradition) => { return tradition.id == traditionId } 
             )
         );
-        TraditionList.highlightFolderSelectedTradition( traditionId );
         SECTION_STORE.setSelectedSection( section );
     }
     

--- a/frontend/www/src/js/modules/dashboard/tradition/section/state.js
+++ b/frontend/www/src/js/modules/dashboard/tradition/section/state.js
@@ -22,7 +22,7 @@ class SectionStore extends StateStore {
 
   /** @param {Section} selectedSection */
   setSelectedSection( selectedSection ) {
-    sectionStoreService.listSections( TRADITION_STORE.state.selectedTradition.id ).then((res) => {
+    return sectionStoreService.listSections( TRADITION_STORE.state.selectedTradition.id ).then( (res) => {
       if (res.success) {
         const availableSections = res.data;
         // refresh state of Section,it may be stale.
@@ -34,8 +34,9 @@ class SectionStore extends StateStore {
       } else {
         StemmawebAlert.show( `Error: ${resp.message}`, 'danger' );
       }
-    });
+    } );
   }
+
 
   /**
    * @returns {number} The index of the currently selected section in the list of

--- a/frontend/www/src/js/modules/dashboard/tradition/state.js
+++ b/frontend/www/src/js/modules/dashboard/tradition/state.js
@@ -116,7 +116,10 @@ function initState() {
       /** @type {Tradition[]} */
       const availableTraditions = res.data;
       availableTraditions.sort( sortAlphabetical );
-      const selectedTradition = availableTraditions[0];
+      let selectedTradition = availableTraditions[0];
+      if( AUTH_STORE.state.user ) {
+        selectedTradition = availableTraditions.find( (tradition) => tradition.owner == AUTH_STORE.state.user.id );
+      }
       /** @type {TraditionState} */
       const state = { availableTraditions, selectedTradition };
       TRADITION_STORE.setState(state);

--- a/frontend/www/src/js/modules/dashboard/tradition/state.js
+++ b/frontend/www/src/js/modules/dashboard/tradition/state.js
@@ -89,6 +89,11 @@ const TRADITION_STORE = new TraditionStore({
 });
 
 
+function sortAlphabetical( tradition_a, tradition_b ) {
+  return tradition_a.name.localeCompare( tradition_b.name );
+}
+
+// 20260218 Not used anymore at this point.
 function sortPrivatePublicThenAlphabetical( tradition_a, tradition_b ) {
   var a;
   var b;
@@ -110,7 +115,7 @@ function initState() {
     if (res.success) {
       /** @type {Tradition[]} */
       const availableTraditions = res.data;
-      availableTraditions.sort( sortPrivatePublicThenAlphabetical );
+      availableTraditions.sort( sortAlphabetical );
       const selectedTradition = availableTraditions[0];
       /** @type {TraditionState} */
       const state = { availableTraditions, selectedTradition };

--- a/frontend/www/src/js/modules/dashboard/tradition/stemma/stemmaButtons.js
+++ b/frontend/www/src/js/modules/dashboard/tradition/stemma/stemmaButtons.js
@@ -19,34 +19,16 @@ class StemmaButtons extends HTMLElement {
      *  needs to be shown and what button needs to be highlighted and
      *  un-highligthed.
      */
-    
-    document.querySelector( '#view-stemmata-button' ).addEventListener( 'click', this.setView );
-    document.querySelector( '#run-stemweb-button' ).addEventListener( 'click', stemwebFrontend.showDialog );
+
+    document.querySelector('#view-stemmata-button').addEventListener('click', this.setView);
+    document.querySelector('#run-stemweb-button').addEventListener('click', stemwebFrontend.showDialog);
     // We want this in the below call to be this class, hence the `.call`, otherwise it will be the button element clicked.
-    document.querySelector( '#edit-collation-button' ).addEventListener( 'click', (event) => { this.setView.call( this, event ) } );
-    document.querySelector( '#delete-tradition-button' ).addEventListener( 'click', this.handleDelete );
+    document.querySelector('#edit-collation-button').addEventListener('click', (event) => { this.setView.call(this, event) });
+    document.querySelector('#delete-tradition-button').addEventListener('click', this.handleDelete);
 
-    SECTION_STORE.subscribe( this.toggleEditCollationButtonActive );
-    TRADITION_STORE.subscribe( ( state ) => { this.greyOut(); } );
-    
-    fadeIn( this );
-  }
+    TRADITION_STORE.subscribe((state) => { this.greyOut(); });
 
-  /** 
-   * This takes care of the edit collation button to be greyed out
-   * if there is no section selected.
-   */
-  toggleEditCollationButtonActive() {
-    const editCollationButtonElement = document.querySelector( '#edit-collation-button' );
-    if( SECTION_STORE.state.selectedSection ) {
-      if ( editCollationButtonElement.classList.contains( 'disabled' ) ) {
-        editCollationButtonElement.classList.remove( 'disabled' );
-      }
-    } else {
-      if ( !editCollationButtonElement.classList.contains( 'disabled' ) ) {
-        editCollationButtonElement.classList.add( 'disabled' );
-      }
-    }
+    fadeIn(this);
   }
 
   /**
@@ -54,69 +36,72 @@ class StemmaButtons extends HTMLElement {
    * component when a user logs in or out.
    */
   greyOut() {
-    const buttonIds = [ 'run-stemweb-button', 'edit-collation-button', 'delete-tradition-button' ];
-    buttonIds.forEach( (buttonId) => {
-      document.querySelector( `#${buttonId}` ).classList.remove( 'disabled' );
-      if( !userIsOwner() ){
-        document.querySelector( `#${buttonId}` ).classList.add( 'disabled' );
+    const buttonIds = ['run-stemweb-button', 'edit-collation-button', 'delete-tradition-button'];
+    buttonIds.forEach((buttonId) => {
+      document.querySelector(`#${buttonId}`).classList.remove('disabled');
+      if (!userIsOwner()) {
+        document.querySelector(`#${buttonId}`).classList.add('disabled');
       }
-    } );
+    });
   }
 
-  setView( evt ) {
-    const currentView = document.querySelector( '#view-selectors .selected-view ' );
+  setView(evt) {
+    const currentView = document.querySelector('#view-selectors .selected-view ');
     var targetView = null;
     var fadeOutElement = null;
-    if ( !( evt.currentTarget == currentView ) ) {
+    if (!(evt.currentTarget == currentView)) {
       // Set the right button to highlight.
-      currentView.classList.remove( 'selected-view' );
-      evt.currentTarget.classList.add( 'selected-view' );
+      currentView.classList.remove('selected-view');
+      evt.currentTarget.classList.add('selected-view');
       // Figure out the chosen view (targetView) and do what needs to happen to prepare it.
-      if ( evt.currentTarget == document.querySelector( '#view-stemmata-button' ) ) {
-        targetView = document.querySelector( '#stemma-editor-graph-container' );
+      if (evt.currentTarget == document.querySelector('#view-stemmata-button')) {
+        targetView = document.querySelector('#stemma-editor-graph-container');
       }
-      if ( evt.currentTarget == document.querySelector( '#edit-collation-button' ) ) {
-        targetView = document.querySelector( 'relation-mapper' );     
+      if (evt.currentTarget == document.querySelector('#edit-collation-button')) {
+        targetView = document.querySelector('relation-mapper');
         var section = SECTION_STORE.state.selectedSection;
         const traditionId = TRADITION_STORE.state.selectedTradition.id;
-        // TODO: THe idea here was that If no section is selected but the user clicks the 'Edit Collation' button
-        // this would select the first section of SectionList.#sections. This works, but the relationmapper needs
-        // all section of a tradition in proper order within the state object. So we need something else here.
-        // NOTE: The original request was: if a user clicks on the greyed out 'Edit Collation' button, message
-        // the user "you need to select a section first". However, I thought this might be a good solution too. Actually
-        // because Bootstrap has no way of detecting clicks on a greyed out button (it sets `pointer-events: none` in CSS).
-        // if ( !section ) {
-        //   section = document.querySelector( `section-list[trad-id="${traditionId}"]` ).getFirstSection();
-        //   console.log( 'done', section );
-        // }
-        if( section ) {
-          stemmaButtonsService.getSectionDot( traditionId, section.id )
-            .then( (resp) => { this.switchToRelationMapper( resp, section.id ) } );
-        }     
+        // In the case no section was selected by the user, we select the first section of the current tradition.
+        if (!section) {
+          section = document.querySelector( `section-list[trad-id="${traditionId}"]` ).getFirstSection();
+          SECTION_STORE.setSelectedSection( section ).then(
+            this.getSectionDot( traditionId, section.id ).then( (resp) => {
+              this.switchToRelationMapper( resp, section.id );
+            } )
+          );
+        } else {
+          this.getSectionDot( traditionId, section.id ).then( (resp) => 
+            this.switchToRelationMapper(resp, section.id)
+          );
+        }
       }
       // Figure out which view we are closing, set that as element to 
       // fade out, and remove or stash stuff from the view we are closing.
-      if ( currentView == document.querySelector( '#edit-collation-button' ) ) {
-        document.querySelector( '#section-title' ).innerHTML = '';
-        fadeOutElement = document.querySelector( 'relation-mapper' );
-        document.querySelector( '#main' ).classList.remove( 'col-9' );
-        document.querySelector( '#main' ).classList.add( 'col-7' );
-        document.querySelector( 'relation-types' ).unrender();
-        document.querySelector( 'node-density-chart' ).hide();
-        document.querySelector( 'reading-properties-view' ).hide();
-        document.querySelector( 'property-table-view' ).show();
-        document.querySelector( 'section-properties-view' ).show();
-        fadeToDisplayNone( '#sidebar-menu', { 'reverse': true, 'delay': 500 } );
-        crossFade( targetView, fadeOutElement ); 
+      if (currentView == document.querySelector('#edit-collation-button')) {
+        document.querySelector('#section-title').innerHTML = '';
+        fadeOutElement = document.querySelector('relation-mapper');
+        document.querySelector('#main').classList.remove('col-9');
+        document.querySelector('#main').classList.add('col-7');
+        document.querySelector('relation-types').unrender();
+        document.querySelector('node-density-chart').hide();
+        document.querySelector('reading-properties-view').hide();
+        document.querySelector('property-table-view').show();
+        document.querySelector('section-properties-view').show();
+        fadeToDisplayNone('#sidebar-menu', { 'reverse': true, 'delay': 500 });
+        crossFade(targetView, fadeOutElement);
       }
     }
   }
 
-  switchToRelationMapper( resp, sectionId ) {
-    if ( resp.success ) {
+  getSectionDot(traditionId, sectionId) {
+    return stemmaButtonsService.getSectionDot( traditionId, sectionId );
+  }
+
+  switchToRelationMapper(resp, sectionId) {
+    if (resp.success) {
       SectionSelectors.renderSectionSelectors();
-      this.closeStemmaView( 
-        { 'onEnd': () => { this.openRelationView( resp, sectionId ) } }
+      this.closeStemmaView(
+        { 'onEnd': () => { this.openRelationView(resp, sectionId) } }
       );
     } else {
       StemmawebAlert.show(
@@ -126,89 +111,90 @@ class StemmaButtons extends HTMLElement {
     }
   }
 
-  closeStemmaView( options ) {
-    const defaultOptions =  { 
-      'onEnd': () => {}
+  closeStemmaView(options) {
+    const defaultOptions = {
+      'onEnd': () => { }
     };
     const usedOptions = { ...defaultOptions, ...options };
-    const fadeOutElement = document.querySelector( '#stemma-editor-graph-container' );
-    fadeToDisplayNone( '#sidebar-menu', { 'delay': 0 } );
-    document.querySelector( '#main' ).classList.remove( 'col-7' );
-    document.querySelector( '#main' ).classList.add( 'col-9' ); // Timed in CSS to 1s with 500ms delay, hence duration of 1500 in next line.
-    fadeToDisplayNone( fadeOutElement, { 
-      'duration': 1500, 
+    const fadeOutElement = document.querySelector('#stemma-editor-graph-container');
+    fadeToDisplayNone('#sidebar-menu', { 'delay': 0 });
+    document.querySelector('#main').classList.remove('col-7');
+    document.querySelector('#main').classList.add('col-9'); // Timed in CSS to 1s with 500ms delay, hence duration of 1500 in next line.
+    fadeToDisplayNone(fadeOutElement, {
+      'duration': 1500,
       'onEnd': () => {
-        usedOptions.onEnd(); 
-      } 
-    } );
+        usedOptions.onEnd();
+      }
+    });
   }
 
-  openRelationView( resp, sectionId ) {
+  openRelationView(resp, sectionId) {
     // TODO: There is a enormous overlap between this code and
     // code doing practically the same thing in `sectionSelectors.js`
     // Both should probably call some extracted.
-    relationRenderer.renderRelationsGraph( 
+    relationRenderer.renderRelationsGraph(
       resp.data, {
-        'onEnd': () => { 
-          this.setSectionTitle();
-          this.addInRelations( sectionId );
-          this.addInReadingInformation( sectionId );
-          this.renderDensityChart();
-          document.querySelector( 'reading-properties-view' ).show();
-          this.hideIrrelevantPropertyViews();
-          const relationMapperElement = document.querySelector( 'relation-mapper' );
-          fadeToDisplayFlex( relationMapperElement, { 'duration': 1500 } );
-        }
+      'onEnd': () => {
+        this.setSectionTitle();
+        this.addInRelations(sectionId);
+        this.addInReadingInformation(sectionId);
+        this.renderDensityChart();
+        document.querySelector('reading-properties-view').show();
+        this.hideIrrelevantPropertyViews();
+        const relationMapperElement = document.querySelector('relation-mapper');
+        fadeToDisplayFlex(relationMapperElement, { 'duration': 1500 });
       }
+    }
     );
   }
 
-  addInRelations( sectionId ) {
-    stemmaButtonsService.getSectionRelations( TRADITION_STORE.state.selectedTradition.id, sectionId ).then( (resp) => {
-      if ( resp.success ) {
-        document.querySelector( 'relation-types' ).renderRelationTypes(
-          { 'onEnd': () => { fadeToDisplayNone( document.querySelector( 'relation-types div' ), { 'reverse': true } ) } }
+  addInRelations(sectionId) {
+    stemmaButtonsService.getSectionRelations(TRADITION_STORE.state.selectedTradition.id, sectionId).then((resp) => {
+      if (resp.success) {
+        document.querySelector('relation-types').renderRelationTypes(
+          { 'onEnd': () => { fadeToDisplayNone(document.querySelector('relation-types div'), { 'reverse': true }) } }
         );
-        RelationMapper.addRelations( resp.data );
+        RelationMapper.addRelations(resp.data);
       } else {
         StemmawebAlert.show(
           `Could not fetch relations information: ${resp.message}`,
           'danger'
-        );                
+        );
       }
-    } );
-  }  
-
-  setSectionTitle() {
-    document.querySelector( '#section-title' ).innerHTML = `${SECTION_STORE.state.selectedSection.name}`;
+    });
   }
 
-  addInReadingInformation( sectionId ) {
-    stemmaButtonsService.getSectionReadings( TRADITION_STORE.state.selectedTradition.id, sectionId ).then( (resp) => {
-      if ( resp.success ) {
-        RelationMapper.addReadings( resp.data );
+  setSectionTitle() {
+    document.querySelector('#section-title').innerHTML = `${SECTION_STORE.state.selectedSection.name}`;
+  }
+
+  addInReadingInformation(sectionId) {
+    stemmaButtonsService.getSectionReadings(TRADITION_STORE.state.selectedTradition.id, sectionId).then((resp) => {
+      if (resp.success) {
+        RelationMapper.addReadings(resp.data);
       } else {
         StemmawebAlert.show(
           `Could not fetch reading information: ${resp.message}`,
           'danger'
-        );                
+        );
       }
-    } );
+    });
   }
 
   renderDensityChart() {
-    document.querySelector( 'node-density-chart' ).renderChart(
-      { 'onEnd': () => { 
-          fadeToDisplayNone( document.querySelector( 'node-density-chart div' ), { 'reverse': true } );
+    document.querySelector('node-density-chart').renderChart(
+      {
+        'onEnd': () => {
+          fadeToDisplayNone(document.querySelector('node-density-chart div'), { 'reverse': true });
         }
       }
     );
   }
-  
+
   hideIrrelevantPropertyViews() {
-    document.querySelector( 'property-table-view' ).hide();
-    document.querySelector( 'section-properties-view' ).hide();
-  } 
+    document.querySelector('property-table-view').hide();
+    document.querySelector('section-properties-view').hide();
+  }
 
   handleDelete() {
     const { selectedTradition: tradition, availableTraditions } =

--- a/frontend/www/src/js/modules/dashboard/tradition/stemma/stemmaButtons.js
+++ b/frontend/www/src/js/modules/dashboard/tradition/stemma/stemmaButtons.js
@@ -26,8 +26,8 @@ class StemmaButtons extends HTMLElement {
     document.querySelector('#edit-collation-button').addEventListener('click', (event) => { this.setView.call(this, event) });
     document.querySelector('#delete-tradition-button').addEventListener('click', this.handleDelete);
 
-    TRADITION_STORE.subscribe((state) => { this.greyOut(); });
-
+    AUTH_STORE.subscribe( ( state ) => { this.greyOut(); } )
+    TRADITION_STORE.subscribe( (state) => { this.greyOut(); } );
     fadeIn(this);
   }
 
@@ -36,13 +36,22 @@ class StemmaButtons extends HTMLElement {
    * component when a user logs in or out.
    */
   greyOut() {
-    const buttonIds = ['run-stemweb-button', 'edit-collation-button', 'delete-tradition-button'];
+    const buttonIds = ['run-stemweb-button', 'delete-tradition-button'];
     buttonIds.forEach((buttonId) => {
       document.querySelector(`#${buttonId}`).classList.remove('disabled');
       if (!userIsOwner()) {
         document.querySelector(`#${buttonId}`).classList.add('disabled');
       }
     });
+    const editCollationButton = document.querySelector(`#edit-collation-button`);
+    editCollationButton.classList.remove( 'disabled' );
+    const VIEW_COLLATION = 'View Collation';
+    const EDIT_COLLATION = 'Edit Collation';
+    let editCollationButtonText = VIEW_COLLATION;
+    if ( userIsOwner() ) {
+      editCollationButtonText = EDIT_COLLATION;
+    }
+    editCollationButton.innerHTML = editCollationButtonText;
   }
 
   setView(evt) {

--- a/frontend/www/src/js/modules/dashboard/tradition/stemma/stemmaButtons.js
+++ b/frontend/www/src/js/modules/dashboard/tradition/stemma/stemmaButtons.js
@@ -78,12 +78,19 @@ class StemmaButtons extends HTMLElement {
       if ( evt.currentTarget == document.querySelector( '#edit-collation-button' ) ) {
         targetView = document.querySelector( 'relation-mapper' );     
         var section = SECTION_STORE.state.selectedSection;
-        if ( !section ) {
-          section = SECTION_STORE.state.availableSections[0];
-          SECTION_STORE.setSelectedSection( section );
-        }
+        const traditionId = TRADITION_STORE.state.selectedTradition.id;
+        // TODO: THe idea here was that If no section is selected but the user clicks the 'Edit Collation' button
+        // this would select the first section of SectionList.#sections. This works, but the relationmapper needs
+        // all section of a tradition in proper order within the state object. So we need something else here.
+        // NOTE: The original request was: if a user clicks on the greyed out 'Edit Collation' button, message
+        // the user "you need to select a section first". However, I thought this might be a good solution too. Actually
+        // because Bootstrap has no way of detecting clicks on a greyed out button (it sets `pointer-events: none` in CSS).
+        // if ( !section ) {
+        //   section = document.querySelector( `section-list[trad-id="${traditionId}"]` ).getFirstSection();
+        //   console.log( 'done', section );
+        // }
         if( section ) {
-          stemmaButtonsService.getSectionDot( TRADITION_STORE.state.selectedTradition.id, section.id )
+          stemmaButtonsService.getSectionDot( traditionId, section.id )
             .then( (resp) => { this.switchToRelationMapper( resp, section.id ) } );
         }     
       }

--- a/frontend/www/src/js/modules/dashboard/tradition/traditionList.js
+++ b/frontend/www/src/js/modules/dashboard/tradition/traditionList.js
@@ -52,30 +52,15 @@ class TraditionList extends HTMLElement {
                 if ( prevState.selectedTradition.name != state.selectedTradition.name ) {
                     this.querySelector( `a[trad-id="${state.selectedTradition.id}"].nav-link span.tradition-nav-name` ).innerHTML = state.selectedTradition.name;
                 }
+                // The case where another tradition was selected.
+                if ( prevState.selectedTradition != state.selectedTradition ) {
+                    this.highlightFolderIcon( state.selectedTradition );
+                }
             }
         });
       }
     
     connectedCallback() {
-    }
-
-    /**
-     * Stores clicked/selected tradition in state object.
-     * Prevents default action (i.e. following the canonical link).
-     * 
-     * @param {Event} evt 
-     * @param {Tradition} tradition 
-     */
-    selectTradition( evt, tradition ) {
-        evt.preventDefault();
-        TraditionList.highlightFolderSelectedTradition( tradition.id );
-        TRADITION_STORE.setSelectedTradition( tradition );
-        SECTION_STORE.setSelectedSection( null );
-    }
-    
-    static highlightFolderSelectedTradition( tradition_id ){
-        document.querySelector( '#traditions-list div.folder-icon.selected' ).classList.toggle( 'selected' );
-        document.querySelector( `#traditions-list div.folder-icon[trad-id="${tradition_id}"]` ).classList.toggle( 'selected' );
     }
 
     /**
@@ -85,18 +70,44 @@ class TraditionList extends HTMLElement {
      * @param {Tradition} tradition 
      */
     toggleSectionList( tradition ){
-        document.querySelector( '#traditions-list div.folder-icon.selected' ).classList.toggle( 'selected' );
-        document.querySelector( `#traditions-list div.folder-icon[trad-id="${tradition.id}"]` ).classList.toggle( 'selected' );
-        TRADITION_STORE.setSelectedTradition( tradition );
+        const traditionSelected = TRADITION_STORE.state.selectedTradition.id == tradition.id ? true : false;
+        const sectionListElement = document.querySelector( `section-list[trad-id="${tradition.id}"]` );
+        const selectionListOpen = sectionListElement.classList.contains( 'show' );
+        
+        // In all cases set selected_section to null.
         SECTION_STORE.setSelectedSection( null );
-        const sectionListElement = this.querySelector( `section-list[trad-id="${tradition.id}"]` );
-        fadeIn( sectionListElement ); 
-        sectionListElement.classList.toggle( 'show' );
-        if ( sectionListElement.classList.contains( 'show' ) ) {
-            sectionListElement.querySelector( 'li.nav-item' ).dispatchEvent( new Event( 'mousedown' ) );
+
+        // Toggle selection list.
+        if( selectionListOpen ) {
+            traditionSelected && this.closeSectionList( sectionListElement );
+        } else {
+            this.openSectionList( sectionListElement );
+        }
+
+        // Select tradition.
+        if ( !traditionSelected ) {
+            TRADITION_STORE.setSelectedTradition( tradition );
         }
     }
-    
+
+    highlightFolderIcon( tradition ) {
+        document.querySelector( '#traditions-list div.folder-icon.selected' ).classList.toggle( 'selected' );
+        document.querySelector( `#traditions-list div.folder-icon[trad-id="${tradition.id}"]` ).classList.toggle( 'selected' );
+    }
+
+    openSectionList( sectionListElement ) {
+        sectionListElement.classList.toggle( 'show' )
+        fadeToDisplayNone( sectionListElement, { 
+            'reverse': true
+        } );
+    }
+
+    closeSectionList( sectionListElement ) {
+        fadeToDisplayNone(sectionListElement, {
+            'onEnd': () => sectionListElement.classList.toggle('show')
+        });
+    }
+
     /**
      * Creates a list item for a tradition to be added to the 
      * traditions and sections navigation tree.
@@ -117,9 +128,9 @@ class TraditionList extends HTMLElement {
         }
         traditionListItem.innerHTML = `
             <div class="tradition-list-item d-flex">
-                <div class="folder-icon${selected}" trad-id="${tradition.id}">${folderIcon}</div>
                 <div>
                     <a href="api/tradition/${tradition.id}" trad-id="${tradition.id}" class="nav-link">
+                        <div class="folder-icon${selected}" trad-id="${tradition.id}">${folderIcon}</div>
                         <span class="tradition-nav-name">${tradition.name}</span>
                     </a>
                 </div>${accessIcon}                
@@ -127,13 +138,13 @@ class TraditionList extends HTMLElement {
             <div>
                 <section-list trad-id="${tradition.id}" class="collapse"></section-list>
             </div>`
-        // traditionListItem.querySelector( 'div div a' ).addEventListener( 'click', (evt) => { this.selectTradition( evt, tradition ) } );
+
+        // Set click actions.
         traditionListItem.querySelector( 'div div a' ).addEventListener( 'click', (evt) => { 
             evt.preventDefault();
-            const sectId = traditionListItem.querySelector( 'div section-list div' ).getAttribute( 'sect-id' );
             this.toggleSectionList( tradition );
         } );
-        traditionListItem.querySelector( 'div div.folder-icon' ).addEventListener( 'click', () => { this.toggleSectionList( tradition ) } );
+
         return traditionListItem;
     }
 
@@ -160,10 +171,10 @@ class TraditionList extends HTMLElement {
         let publicTraditions = [];
         if ( AUTH_STORE.state.user ) {
             ownedTraditions = traditions.filter( (tradition) => {
-                return ( tradition.owner == AUTH_STORE.state.user.id );
-            } );
+                return ( tradition.owner == AUTH_STORE.state.user.id || userIsAdmin() );
+            } );   
             publicTraditions = traditions.filter( (tradition) => {
-                return ( ( tradition.owner != AUTH_STORE.state.user.id ) && tradition.is_public );
+                return ( ( tradition.owner != AUTH_STORE.state.user.id ) && tradition.is_public && !userIsAdmin() );
             })
         } else {
             publicTraditions = traditions.filter( (tradition) => tradition.is_public )
@@ -173,8 +184,8 @@ class TraditionList extends HTMLElement {
         ownedTraditions.forEach( (tradition) => {
             traditionListElement.appendChild( this.createTraditionListItem( tradition ) )
         } );
-        // If there are any owned traditions, add a list separator.
-        if ( traditionListElement.querySelector( 'li' ) ) {
+        // If there are both owned and public traditions, add a list separator.
+        if ( ownedTraditions.length > 0 && publicTraditions.length > 0 ) {
             traditionListElement.appendChild( this.createListSeparator() );
         }
         // Lastly, add the public traditions.

--- a/frontend/www/src/js/modules/dashboard/tradition/traditionList.js
+++ b/frontend/www/src/js/modules/dashboard/tradition/traditionList.js
@@ -168,16 +168,16 @@ class TraditionList extends HTMLElement {
         const traditionListElement = this.querySelector( 'ul' );
 
         let ownedTraditions = [];
-        let publicTraditions = [];
+        let otherAllowedTraditions = [];
         if ( AUTH_STORE.state.user ) {
             ownedTraditions = traditions.filter( (tradition) => {
-                return ( tradition.owner == AUTH_STORE.state.user.id || userIsAdmin() );
+                return ( tradition.owner == AUTH_STORE.state.user.id );
             } );   
-            publicTraditions = traditions.filter( (tradition) => {
-                return ( ( tradition.owner != AUTH_STORE.state.user.id ) && tradition.is_public && !userIsAdmin() );
+            otherAllowedTraditions = traditions.filter( (tradition) => {
+                return ( ( tradition.owner != AUTH_STORE.state.user.id ) && ( tradition.is_public || userIsAdmin() ) );
             })
         } else {
-            publicTraditions = traditions.filter( (tradition) => tradition.is_public )
+            otherAllowedTraditions = traditions.filter( (tradition) => tradition.is_public )
         }
 
 
@@ -185,11 +185,11 @@ class TraditionList extends HTMLElement {
             traditionListElement.appendChild( this.createTraditionListItem( tradition ) )
         } );
         // If there are both owned and public traditions, add a list separator.
-        if ( ownedTraditions.length > 0 && publicTraditions.length > 0 ) {
+        if ( ownedTraditions.length > 0 && otherAllowedTraditions.length > 0 ) {
             traditionListElement.appendChild( this.createListSeparator() );
         }
         // Lastly, add the public traditions.
-        publicTraditions.forEach( (tradition) => {
+        otherAllowedTraditions.forEach( (tradition) => {
             traditionListElement.appendChild( this.createTraditionListItem( tradition ) )
         } );
         

--- a/frontend/www/src/js/modules/navbar/stemmawebNavigation.js
+++ b/frontend/www/src/js/modules/navbar/stemmawebNavigation.js
@@ -104,8 +104,8 @@ class StemmawebNavigation extends HTMLElement {
         </div>
         <div class="navbar-nav">
           <div class="nav-item text-nowrap">
-            <a class="nav-link px-3">Logged in as ${
-              !user ? 'Guest' : user['email']
+            <a class="nav-link px-3">${
+              !user ? 'Welcome guest' : `Logged in as ${user['email']}`
             }</a>
           </div>
         </div>


### PR DESCRIPTION
PR to get bootstrap_test in sync with bootstrap_frontdev.

What could be tested after this PR, if it was not tested already:

* admin sees all traditions in alphabetical order, no divider.
* user sees owned traditions in alphabetical order, below that a divider, below the divider public traditions alphabetically.
* guest sees public traditions in alphabetical order, no divider.
* click on selected tradition of which section list is closed -> section list opens, no section is selected.
* click on selected tradition of which section list is open -> section list closes, no section is selected.
* click on tradition that is not selected and of which section list is closed -> section list opens, folder icon is highlighted, no section is selected.
* click on tradition that is not selected and of which section list is open -> section list remains open, folder icon is highlighted, no section is selected.
* click on section in tradition that is selected: section is selected, section properties become visible.
* click on section in tradition that is NOT selected: tradition is selected, folder icon is highlighted, section is selected, section properties become visible; other tradition folder icons are not highlighted.
* 'Edit Collation' button only active if a section is selected.